### PR TITLE
ci(workflows): point CI triggers at main after master rename [DEV-5694]

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: Run tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   schedule:
       - cron: '0 0 * * *'


### PR DESCRIPTION
## What

One-line CI fix following today's Wave 0 `master → main` branch rename (Git & Repository Standards rollout, DEV-5694): the workflow trigger still pointed at `master`, so CI stopped firing after the rename.

## Base branch check

- [x] Base is `main` — this is a trunk-only repo (single-branch model).

## Verification

The `pull_request` run on this PR exercises the updated workflow; after merge, the push trigger fires on `main` and completes the repo's Wave 0 checklist item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)